### PR TITLE
Add 16x16 GAN example

### DIFF
--- a/gan/gan.py
+++ b/gan/gan.py
@@ -1,0 +1,270 @@
+import os, sys
+sys.path.append(os.getcwd())
+
+import time
+import csv
+import numpy as np
+import tensorflow as tf
+
+import tflib as lib
+import tflib.ops.linear
+import tflib.ops.conv2d
+import tflib.ops.batchnorm
+import tflib.ops.deconv2d
+
+from spin import Model
+
+# Define spin system and generate training dataset
+geometry = (16,16)
+T = 3.
+n_samples = 2000
+
+x = Model()
+x.generate_system(geometry=geometry, T=T)
+x.generate_ensemble(n_samples=n_samples)
+dataset = x.ensemble.configuration
+dataset = dataset.reshape(n_samples, -1)
+
+# Define GAN parameters
+MODE = 'wgan-gp' # dcgan, wgan, or wgan-gp
+DIM = 64 # Model dimensionality
+BATCH_SIZE = 50 # Batch size
+CRITIC_ITERS = 5 # For WGAN and WGAN-GP, number of critic iters per gen iter
+LAMBDA = 10 # Gradient penalty lambda hyperparameter
+ITERS = 20000 # How many generator iterations to train for 
+OUTPUT_DIM = 16*16 # Number of pixels
+N = geometry[0] # Ising 2D Dim
+EVAL_BATCHES = 40 # Number of batches per eval step
+DATASET_SIZE = n_samples # Number of samples to generate for train dataset
+Z_DIM = 2*2*4*DIM
+
+lib.print_model_settings(locals().copy())
+
+def LeakyReLU(x, alpha=0.2):
+    return tf.maximum(alpha*x, x)
+
+def ReLULayer(name, n_in, n_out, inputs):
+    output = lib.ops.linear.Linear(
+        name+'.Linear', 
+        n_in, 
+        n_out, 
+        inputs,
+        initialization='he'
+    )
+    return tf.nn.relu(output)
+
+def LeakyReLULayer(name, n_in, n_out, inputs):
+    output = lib.ops.linear.Linear(
+        name+'.Linear', 
+        n_in, 
+        n_out, 
+        inputs,
+        initialization='he'
+    )
+    return LeakyReLU(output)
+
+def Generator(n_samples, noise=None):
+
+    if noise is None:
+        noise = tf.random_normal([n_samples, Z_DIM])
+
+    # [n_samples, Z_DIM] -> [n_samples, 2, 2, 4*DIM]
+    output = tf.reshape(noise, [n_samples, 4*DIM, 2, 2])
+
+    # [n_samples, 2, 2, 4*DIM] -> [n_samples, 4, 4, 2*DIM]    
+    output = lib.ops.deconv2d.Deconv2D('Generator.2', 4*DIM, 2*DIM, 5, output)
+    if MODE == 'wgan':
+        output = lib.ops.batchnorm.Batchnorm('Generator.BN2', [0,2,3], output)
+    output = tf.nn.relu(output)
+
+    # [n_samples, 4, 4, 2*DIM] -> [n_samples, 8, 8. DIM]
+    output = lib.ops.deconv2d.Deconv2D('Generator.3', 2*DIM, DIM, 5, output)
+    if MODE == 'wgan':
+        output = lib.ops.batchnorm.Batchnorm('Generator.BN3', [0,2,3], output)
+    output = tf.nn.relu(output)
+
+    # [n_samples, 8, 8, DIM] -> [n_samples, 16, 16, 1] 
+    output = lib.ops.deconv2d.Deconv2D('Generator.5', DIM, 1, 5, output)
+    output = tf.nn.sigmoid(output)
+
+    # Rescale output [0, 1] -> [-1, 1]
+    output = output*2-1
+    return tf.reshape(output, [-1, OUTPUT_DIM])
+
+def Discriminator(inputs):
+
+    # [n_samples, OUTPUT_DIM] -> [n_samples, 16, 16, 1]
+    output = tf.reshape(inputs, [n_samples, 1, N, N])
+
+    # [n_samples, 16, 16, 1] -> [n_samples, 8, 8, DIM]
+    output = lib.ops.conv2d.Conv2D('Discriminator.1', 1, DIM, 4, output, stride=2)
+    output = LeakyReLU(output)
+
+    # [n_samples, 8, 8, DIM] -> [n_samples, 4, 4, 2*DIM]
+    output = lib.ops.conv2d.Conv2D('Discriminator.2', DIM, 2*DIM, 4, output, stride=2)
+    if MODE == 'wgan':
+        output = lib.ops.batchnorm.Batchnorm('Discriminator.BN2', [0,2,3], output)
+    output = LeakyReLU(output)
+
+    # [n_samples, 4, 4, 2*DIM] -> [n_samples, 2, 2, 4*DIM]
+    output = lib.ops.conv2d.Conv2D('Discriminator.3', 2*DIM, 4*DIM, 5, output, stride=2)
+    if MODE == 'wgan':
+        output = lib.ops.batchnorm.Batchnorm('Discriminator.BN3', [0,2,3], output)
+    output = LeakyReLU(output)
+
+    output = tf.reshape(output, [n_samples, 2*2*4*DIM])
+    output = lib.ops.linear.Linear('Discriminator.Output', 2*2*4*DIM, 1, output)
+
+    return tf.reshape(output, [-1])
+
+real_data = tf.placeholder(tf.float32, shape=[BATCH_SIZE, OUTPUT_DIM])
+fake_data = Generator(BATCH_SIZE)
+
+disc_real = Discriminator(real_data)
+disc_fake = Discriminator(fake_data)
+
+gen_params = lib.params_with_name('Generator')
+disc_params = lib.params_with_name('Discriminator')
+
+if MODE == 'wgan':
+    gen_cost = -tf.reduce_mean(disc_fake)
+    disc_cost = tf.reduce_mean(disc_fake) - tf.reduce_mean(disc_real)
+
+    gen_train_op = tf.train.RMSPropOptimizer(
+        learning_rate=5e-5
+    ).minimize(gen_cost, var_list=gen_params)
+    disc_train_op = tf.train.RMSPropOptimizer(
+        learning_rate=5e-5
+    ).minimize(disc_cost, var_list=disc_params)
+
+    clip_ops = []
+    for var in lib.params_with_name('Discriminator'):
+        clip_bounds = [-.01, .01]
+        clip_ops.append(
+            tf.assign(
+                var, 
+                tf.clip_by_value(var, clip_bounds[0], clip_bounds[1])
+            )
+        )
+    clip_disc_weights = tf.group(*clip_ops)
+
+elif MODE == 'wgan-gp':
+    gen_cost = -tf.reduce_mean(disc_fake)
+    disc_cost = tf.reduce_mean(disc_fake) - tf.reduce_mean(disc_real)
+
+    alpha = tf.random_uniform(
+        shape=[BATCH_SIZE,1], 
+        minval=0.,
+        maxval=1.
+    )
+    differences = fake_data - real_data
+    interpolates = real_data + (alpha*differences)
+    gradients = tf.gradients(Discriminator(interpolates), [interpolates])[0]
+    slopes = tf.sqrt(tf.reduce_sum(tf.square(gradients), reduction_indices=[1]))
+    gradient_penalty = tf.reduce_mean((slopes-1.)**2)
+    disc_cost += LAMBDA*gradient_penalty
+
+    gen_train_op = tf.train.AdamOptimizer(
+        learning_rate=1e-4, 
+        beta1=0.5,
+        beta2=0.9
+    ).minimize(gen_cost, var_list=gen_params)
+    disc_train_op = tf.train.AdamOptimizer(
+        learning_rate=1e-4, 
+        beta1=0.5, 
+        beta2=0.9
+    ).minimize(disc_cost, var_list=disc_params)
+
+    clip_disc_weights = None
+
+elif MODE == 'dcgan':
+    gen_cost = tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
+        disc_fake, 
+        tf.ones_like(disc_fake)
+    ))
+
+    disc_cost =  tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
+        disc_fake, 
+        tf.zeros_like(disc_fake)
+    ))
+    disc_cost += tf.reduce_mean(tf.nn.sigmoid_cross_entropy_with_logits(
+        disc_real, 
+        tf.ones_like(disc_real)
+    ))
+    disc_cost /= 2.
+
+    gen_train_op = tf.train.AdamOptimizer(
+        learning_rate=2e-4, 
+        beta1=0.5
+    ).minimize(gen_cost, var_list=gen_params)
+    disc_train_op = tf.train.AdamOptimizer(
+        learning_rate=2e-4, 
+        beta1=0.5
+    ).minimize(disc_cost, var_list=disc_params)
+
+    clip_disc_weights = None
+
+# Dataset iterator
+def inf_train_gen():
+    while True:
+        yield dataset[np.random.randint(dataset.shape[0], size=BATCH_SIZE), :]
+
+# Train loop
+with tf.Session() as session:
+
+    session.run(tf.initialize_all_variables())
+
+    gen = inf_train_gen()
+
+    gen_costs = []
+    disc_costs = []
+
+    for iteration in xrange(ITERS):
+        start_time = time.time()
+
+        if iteration > 0:
+            _, _gen_cost = session.run([gen_train_op, gen_cost])
+            gen_costs.append(_gen_cost)
+
+        if MODE == 'dcgan':
+            disc_iters = 1
+        else:
+            disc_iters = CRITIC_ITERS
+        for i in xrange(disc_iters):
+            _data = gen.next()
+            _disc_cost, _ = session.run(
+                [disc_cost, disc_train_op],
+                feed_dict={real_data: _data}
+            )
+            disc_costs.append(_disc_cost)
+            if clip_disc_weights is not None:
+                _ = session.run(clip_disc_weights)
+            
+        if iteration % 50 == 49:
+          print("iteration %d" % iteration)
+          print("gen_cost: %f" % np.mean(np.array(gen_costs)))
+          print("disc_cost: %f" % np.mean(np.array(disc_costs)))
+          gen_costs = []
+          disc_costs = []
+
+
+        # Code for evaluating fake data, waiting for similar code in spin to appear
+        #if iteration % 2000 == 1999:
+        #  print("Generating samples and calculating properties")
+        #  fake_dataset = []
+        #  for j in range(EVAL_BATCHES):
+        #    fake_dataset.append(session.run(fake_data))
+        #  fake_dataset = np.stack(fake_dataset).reshape((-1, OUTPUT_DIM))
+        #  fake_dataset = np.sign(fake_dataset)
+        #  np.savetxt(samples_filename, fake_dataset)
+        #  te, tm, tsh, tss = evaluate_ising_data(T, N, fake_dataset)
+        #  
+        #  with open(gen_filename, "a") as f:
+        #    writer = csv.writer(f)
+        #    writer.writerow([te,tm,tsh,tss])
+    
+        #  print("Test Energy: %f True Energy: %f Diff: %f" % (te, e, te-e))
+        #  print("Test Magnetization: %f True Magnetization %f Diff: %f" % (tm, m, tm-m))
+        #  print("Test Specific Heat: %f True Specific Heat: %f Diff: %f" % (tsh, sh, tsh-sh))
+        #  print("Test Susceptibility: %f True Susceptibility: %f Diff: %f" % (tss, ss, tss-ss))
+

--- a/gan/tflib/__init__.py
+++ b/gan/tflib/__init__.py
@@ -1,0 +1,63 @@
+import numpy as np
+import tensorflow as tf
+
+import locale
+
+locale.setlocale(locale.LC_ALL, '')
+
+_params = {}
+_param_aliases = {}
+def param(name, *args, **kwargs):
+    """
+    A wrapper for `tf.Variable` which enables parameter sharing in models.
+    
+    Creates and returns theano shared variables similarly to `tf.Variable`, 
+    except if you try to create a param with the same name as a 
+    previously-created one, `param(...)` will just return the old one instead of 
+    making a new one.
+
+    This constructor also adds a `param` attribute to the shared variables it 
+    creates, so that you can easily search a graph for all params.
+    """
+
+    if name not in _params:
+        kwargs['name'] = name
+        param = tf.Variable(*args, **kwargs)
+        param.param = True
+        _params[name] = param
+    result = _params[name]
+    i = 0
+    while result in _param_aliases:
+        # print 'following alias {}: {} to {}'.format(i, result, _param_aliases[result])
+        i += 1
+        result = _param_aliases[result]
+    return result
+
+def params_with_name(name):
+    return [p for n,p in _params.items() if name in n]
+
+def delete_all_params():
+    _params.clear()
+
+def alias_params(replace_dict):
+    for old,new in replace_dict.items():
+        # print "aliasing {} to {}".format(old,new)
+        _param_aliases[old] = new
+
+def delete_param_aliases():
+    _param_aliases.clear()
+
+def print_model_settings(locals_):
+    print "Uppercase local vars:"
+    all_vars = [(k,v) for (k,v) in locals_.items() if (k.isupper() and k!='T' and k!='SETTINGS' and k!='ALL_SETTINGS')]
+    all_vars = sorted(all_vars, key=lambda x: x[0])
+    for var_name, var_value in all_vars:
+        print "\t{}: {}".format(var_name, var_value)
+
+
+def print_model_settings_dict(settings):
+    print "Settings dict:"
+    all_vars = [(k,v) for (k,v) in settings.items()]
+    all_vars = sorted(all_vars, key=lambda x: x[0])
+    for var_name, var_value in all_vars:
+        print "\t{}: {}".format(var_name, var_value)

--- a/gan/tflib/ops/batchnorm.py
+++ b/gan/tflib/ops/batchnorm.py
@@ -1,0 +1,87 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+def Batchnorm(name, axes, inputs, is_training=None, stats_iter=None, update_moving_stats=True, fused=False):
+    if ((axes == [0,2,3]) or (axes == [0,2])) and fused==True:
+        if axes==[0,2]:
+            inputs = tf.expand_dims(inputs, 3)
+        # Old (working but pretty slow) implementation:
+        ##########
+
+        # inputs = tf.transpose(inputs, [0,2,3,1])
+
+        # mean, var = tf.nn.moments(inputs, [0,1,2], keep_dims=False)
+        # offset = lib.param(name+'.offset', np.zeros(mean.get_shape()[-1], dtype='float32'))
+        # scale = lib.param(name+'.scale', np.ones(var.get_shape()[-1], dtype='float32'))
+        # result = tf.nn.batch_normalization(inputs, mean, var, offset, scale, 1e-4)
+
+        # return tf.transpose(result, [0,3,1,2])
+
+        # New (super fast but untested) implementation:
+        offset = lib.param(name+'.offset', np.zeros(inputs.get_shape()[1], dtype='float32'))
+        scale = lib.param(name+'.scale', np.ones(inputs.get_shape()[1], dtype='float32'))
+
+        moving_mean = lib.param(name+'.moving_mean', np.zeros(inputs.get_shape()[1], dtype='float32'), trainable=False)
+        moving_variance = lib.param(name+'.moving_variance', np.ones(inputs.get_shape()[1], dtype='float32'), trainable=False)
+
+        def _fused_batch_norm_training():
+            return tf.nn.fused_batch_norm(inputs, scale, offset, epsilon=1e-5, data_format='NCHW')
+        def _fused_batch_norm_inference():
+            # Version which blends in the current item's statistics
+            batch_size = tf.cast(tf.shape(inputs)[0], 'float32')
+            mean, var = tf.nn.moments(inputs, [2,3], keep_dims=True)
+            mean = ((1./batch_size)*mean) + (((batch_size-1.)/batch_size)*moving_mean)[None,:,None,None]
+            var = ((1./batch_size)*var) + (((batch_size-1.)/batch_size)*moving_variance)[None,:,None,None]
+            return tf.nn.batch_normalization(inputs, mean, var, offset[None,:,None,None], scale[None,:,None,None], 1e-5), mean, var
+
+            # Standard version
+            # return tf.nn.fused_batch_norm(
+            #     inputs,
+            #     scale,
+            #     offset,
+            #     epsilon=1e-2, 
+            #     mean=moving_mean,
+            #     variance=moving_variance,
+            #     is_training=False,
+            #     data_format='NCHW'
+            # )
+
+        if is_training is None:
+            outputs, batch_mean, batch_var = _fused_batch_norm_training()
+        else:
+            outputs, batch_mean, batch_var = tf.cond(is_training,
+                                                       _fused_batch_norm_training,
+                                                       _fused_batch_norm_inference)
+            if update_moving_stats:
+                no_updates = lambda: outputs
+                def _force_updates():
+                    """Internal function forces updates moving_vars if is_training."""
+                    float_stats_iter = tf.cast(stats_iter, tf.float32)
+
+                    update_moving_mean = tf.assign(moving_mean, ((float_stats_iter/(float_stats_iter+1))*moving_mean) + ((1/(float_stats_iter+1))*batch_mean))
+                    update_moving_variance = tf.assign(moving_variance, ((float_stats_iter/(float_stats_iter+1))*moving_variance) + ((1/(float_stats_iter+1))*batch_var))
+
+                    with tf.control_dependencies([update_moving_mean, update_moving_variance]):
+                        return tf.identity(outputs)
+                outputs = tf.cond(is_training, _force_updates, no_updates)
+
+        if axes == [0,2]:
+            return outputs[:,:,:,0] # collapse last dim
+        else:
+            return outputs
+    else:
+        # raise Exception('old BN')
+        # TODO we can probably use nn.fused_batch_norm here too for speedup
+        mean, var = tf.nn.moments(inputs, axes, keep_dims=True)
+        shape = mean.get_shape().as_list()
+        if 0 not in axes:
+            print "WARNING ({}): didn't find 0 in axes, but not using separate BN params for each item in batch".format(name)
+            shape[0] = 1
+        offset = lib.param(name+'.offset', np.zeros(shape, dtype='float32'))
+        scale = lib.param(name+'.scale', np.ones(shape, dtype='float32'))
+        result = tf.nn.batch_normalization(inputs, mean, var, offset, scale, 1e-5)
+
+
+        return result

--- a/gan/tflib/ops/conv1d.py
+++ b/gan/tflib/ops/conv1d.py
@@ -1,0 +1,108 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+_default_weightnorm = False
+def enable_default_weightnorm():
+    global _default_weightnorm
+    _default_weightnorm = True
+
+def Conv1D(name, input_dim, output_dim, filter_size, inputs, he_init=True, mask_type=None, stride=1, weightnorm=None, biases=True, gain=1.):
+    """
+    inputs: tensor of shape (batch size, num channels, width)
+    mask_type: one of None, 'a', 'b'
+
+    returns: tensor of shape (batch size, num channels, width)
+    """
+    with tf.name_scope(name) as scope:
+
+        if mask_type is not None:
+            mask_type, mask_n_channels = mask_type
+
+            mask = np.ones(
+                (filter_size, input_dim, output_dim), 
+                dtype='float32'
+            )
+            center = filter_size // 2
+
+            # Mask out future locations
+            # filter shape is (width, input channels, output channels)
+            mask[center+1:, :, :] = 0.
+
+            # Mask out future channels
+            for i in xrange(mask_n_channels):
+                for j in xrange(mask_n_channels):
+                    if (mask_type=='a' and i >= j) or (mask_type=='b' and i > j):
+                        mask[
+                            center,
+                            i::mask_n_channels,
+                            j::mask_n_channels
+                        ] = 0.
+
+
+        def uniform(stdev, size):
+            return np.random.uniform(
+                low=-stdev * np.sqrt(3),
+                high=stdev * np.sqrt(3),
+                size=size
+            ).astype('float32')
+
+        fan_in = input_dim * filter_size
+        fan_out = output_dim * filter_size / stride
+
+        if mask_type is not None: # only approximately correct
+            fan_in /= 2.
+            fan_out /= 2.
+
+        if he_init:
+            filters_stdev = np.sqrt(4./(fan_in+fan_out))
+        else: # Normalized init (Glorot & Bengio)
+            filters_stdev = np.sqrt(2./(fan_in+fan_out))
+
+        filter_values = uniform(
+            filters_stdev,
+            (filter_size, input_dim, output_dim)
+        )
+        # print "WARNING IGNORING GAIN"
+        filter_values *= gain
+
+        filters = lib.param(name+'.Filters', filter_values)
+
+        if weightnorm==None:
+            weightnorm = _default_weightnorm
+        if weightnorm:
+            norm_values = np.sqrt(np.sum(np.square(filter_values), axis=(0,1)))
+            target_norms = lib.param(
+                name + '.g',
+                norm_values
+            )
+            with tf.name_scope('weightnorm') as scope:
+                norms = tf.sqrt(tf.reduce_sum(tf.square(filters), reduction_indices=[0,1]))
+                filters = filters * (target_norms / norms)
+
+        if mask_type is not None:
+            with tf.name_scope('filter_mask'):
+                filters = filters * mask
+
+        result = tf.nn.conv1d(
+            value=inputs, 
+            filters=filters, 
+            stride=stride,
+            padding='SAME',
+            data_format='NCHW'
+        )
+
+        if biases:
+            _biases = lib.param(
+                name+'.Biases',
+                np.zeros([output_dim], dtype='float32')
+            )
+
+            # result = result + _biases
+
+            result = tf.expand_dims(result, 3)
+            result = tf.nn.bias_add(result, _biases, data_format='NCHW')
+            result = tf.squeeze(result)
+
+        return result

--- a/gan/tflib/ops/conv2d.py
+++ b/gan/tflib/ops/conv2d.py
@@ -1,0 +1,123 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+_default_weightnorm = False
+def enable_default_weightnorm():
+    global _default_weightnorm
+    _default_weightnorm = True
+
+_weights_stdev = None
+def set_weights_stdev(weights_stdev):
+    global _weights_stdev
+    _weights_stdev = weights_stdev
+
+def unset_weights_stdev():
+    global _weights_stdev
+    _weights_stdev = None
+
+def Conv2D(name, input_dim, output_dim, filter_size, inputs, he_init=True, mask_type=None, stride=1, weightnorm=None, biases=True, gain=1.):
+    """
+    inputs: tensor of shape (batch size, num channels, height, width)
+    mask_type: one of None, 'a', 'b'
+
+    returns: tensor of shape (batch size, num channels, height, width)
+    """
+    with tf.name_scope(name) as scope:
+
+        if mask_type is not None:
+            mask_type, mask_n_channels = mask_type
+
+            mask = np.ones(
+                (filter_size, filter_size, input_dim, output_dim), 
+                dtype='float32'
+            )
+            center = filter_size // 2
+
+            # Mask out future locations
+            # filter shape is (height, width, input channels, output channels)
+            mask[center+1:, :, :, :] = 0.
+            mask[center, center+1:, :, :] = 0.
+
+            # Mask out future channels
+            for i in xrange(mask_n_channels):
+                for j in xrange(mask_n_channels):
+                    if (mask_type=='a' and i >= j) or (mask_type=='b' and i > j):
+                        mask[
+                            center,
+                            center,
+                            i::mask_n_channels,
+                            j::mask_n_channels
+                        ] = 0.
+
+
+        def uniform(stdev, size):
+            return np.random.uniform(
+                low=-stdev * np.sqrt(3),
+                high=stdev * np.sqrt(3),
+                size=size
+            ).astype('float32')
+
+        fan_in = input_dim * filter_size**2
+        fan_out = output_dim * filter_size**2 / (stride**2)
+
+        if mask_type is not None: # only approximately correct
+            fan_in /= 2.
+            fan_out /= 2.
+
+        if he_init:
+            filters_stdev = np.sqrt(4./(fan_in+fan_out))
+        else: # Normalized init (Glorot & Bengio)
+            filters_stdev = np.sqrt(2./(fan_in+fan_out))
+
+        if _weights_stdev is not None:
+            filter_values = uniform(
+                _weights_stdev,
+                (filter_size, filter_size, input_dim, output_dim)
+            )
+        else:
+            filter_values = uniform(
+                filters_stdev,
+                (filter_size, filter_size, input_dim, output_dim)
+            )
+
+        # print "WARNING IGNORING GAIN"
+        filter_values *= gain
+
+        filters = lib.param(name+'.Filters', filter_values)
+
+        if weightnorm==None:
+            weightnorm = _default_weightnorm
+        if weightnorm:
+            norm_values = np.sqrt(np.sum(np.square(filter_values), axis=(0,1,2)))
+            target_norms = lib.param(
+                name + '.g',
+                norm_values
+            )
+            with tf.name_scope('weightnorm') as scope:
+                norms = tf.sqrt(tf.reduce_sum(tf.square(filters), reduction_indices=[0,1,2]))
+                filters = filters * (target_norms / norms)
+
+        if mask_type is not None:
+            with tf.name_scope('filter_mask'):
+                filters = filters * mask
+
+        result = tf.nn.conv2d(
+            input=inputs, 
+            filter=filters, 
+            strides=[1, 1, stride, stride],
+            padding='SAME',
+            data_format='NCHW'
+        )
+
+        if biases:
+            _biases = lib.param(
+                name+'.Biases',
+                np.zeros(output_dim, dtype='float32')
+            )
+
+            result = tf.nn.bias_add(result, _biases, data_format='NCHW')
+
+
+        return result

--- a/gan/tflib/ops/deconv2d.py
+++ b/gan/tflib/ops/deconv2d.py
@@ -1,0 +1,115 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+_default_weightnorm = False
+def enable_default_weightnorm():
+    global _default_weightnorm
+    _default_weightnorm = True
+
+_weights_stdev = None
+def set_weights_stdev(weights_stdev):
+    global _weights_stdev
+    _weights_stdev = weights_stdev
+
+def unset_weights_stdev():
+    global _weights_stdev
+    _weights_stdev = None
+
+def Deconv2D(
+    name, 
+    input_dim, 
+    output_dim, 
+    filter_size, 
+    inputs, 
+    he_init=True,
+    weightnorm=None,
+    biases=True,
+    gain=1.,
+    mask_type=None,
+    ):
+    """
+    inputs: tensor of shape (batch size, height, width, input_dim)
+    returns: tensor of shape (batch size, 2*height, 2*width, output_dim)
+    """
+    with tf.name_scope(name) as scope:
+
+        if mask_type != None:
+            raise Exception('Unsupported configuration')
+
+        def uniform(stdev, size):
+            return np.random.uniform(
+                low=-stdev * np.sqrt(3),
+                high=stdev * np.sqrt(3),
+                size=size
+            ).astype('float32')
+
+        stride = 2
+        fan_in = input_dim * filter_size**2 / (stride**2)
+        fan_out = output_dim * filter_size**2
+
+        if he_init:
+            filters_stdev = np.sqrt(4./(fan_in+fan_out))
+        else: # Normalized init (Glorot & Bengio)
+            filters_stdev = np.sqrt(2./(fan_in+fan_out))
+
+
+        if _weights_stdev is not None:
+            filter_values = uniform(
+                _weights_stdev,
+                (filter_size, filter_size, output_dim, input_dim)
+            )
+        else:
+            filter_values = uniform(
+                filters_stdev,
+                (filter_size, filter_size, output_dim, input_dim)
+            )
+
+        filter_values *= gain
+
+        filters = lib.param(
+            name+'.Filters',
+            filter_values
+        )
+
+        if weightnorm==None:
+            weightnorm = _default_weightnorm
+        if weightnorm:
+            norm_values = np.sqrt(np.sum(np.square(filter_values), axis=(0,1,3)))
+            target_norms = lib.param(
+                name + '.g',
+                norm_values
+            )
+            with tf.name_scope('weightnorm') as scope:
+                norms = tf.sqrt(tf.reduce_sum(tf.square(filters), reduction_indices=[0,1,3]))
+                filters = filters * tf.expand_dims(target_norms / norms, 1)
+
+
+        inputs = tf.transpose(inputs, [0,2,3,1], name='NCHW_to_NHWC')
+
+        input_shape = tf.shape(inputs)
+        try: # tf pre-1.0 (top) vs 1.0 (bottom)
+            output_shape = tf.pack([input_shape[0], 2*input_shape[1], 2*input_shape[2], output_dim])
+        except Exception as e:
+            output_shape = tf.stack([input_shape[0], 2*input_shape[1], 2*input_shape[2], output_dim])
+
+        result = tf.nn.conv2d_transpose(
+            value=inputs, 
+            filter=filters,
+            output_shape=output_shape, 
+            strides=[1, 2, 2, 1],
+            padding='SAME'
+        )
+
+        if biases:
+            _biases = lib.param(
+                name+'.Biases',
+                np.zeros(output_dim, dtype='float32')
+            )
+            result = tf.nn.bias_add(result, _biases)
+
+        result = tf.transpose(result, [0,3,1,2], name='NHWC_to_NCHW')
+
+
+        return result

--- a/gan/tflib/ops/layernorm.py
+++ b/gan/tflib/ops/layernorm.py
@@ -1,0 +1,21 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+def Layernorm(name, norm_axes, inputs):
+    mean, var = tf.nn.moments(inputs, norm_axes, keep_dims=True)
+
+    # Assume the 'neurons' axis is the first of norm_axes. This is the case for fully-connected and BCHW conv layers.
+    n_neurons = inputs.get_shape().as_list()[norm_axes[0]]
+
+    offset = lib.param(name+'.offset', np.zeros(n_neurons, dtype='float32'))
+    scale = lib.param(name+'.scale', np.ones(n_neurons, dtype='float32'))
+
+    # Add broadcasting dims to offset and scale (e.g. BCHW conv data)
+    offset = tf.reshape(offset, [-1] + [1 for i in xrange(len(norm_axes)-1)])
+    scale = tf.reshape(scale, [-1] + [1 for i in xrange(len(norm_axes)-1)])
+
+    result = tf.nn.batch_normalization(inputs, mean, var, offset, scale, 1e-5)
+
+    return result

--- a/gan/tflib/ops/linear.py
+++ b/gan/tflib/ops/linear.py
@@ -1,0 +1,148 @@
+import tflib as lib
+
+import numpy as np
+import tensorflow as tf
+
+_default_weightnorm = False
+def enable_default_weightnorm():
+    global _default_weightnorm
+    _default_weightnorm = True
+
+def disable_default_weightnorm():
+    global _default_weightnorm
+    _default_weightnorm = False
+
+_weights_stdev = None
+def set_weights_stdev(weights_stdev):
+    global _weights_stdev
+    _weights_stdev = weights_stdev
+
+def unset_weights_stdev():
+    global _weights_stdev
+    _weights_stdev = None
+
+def Linear(
+        name, 
+        input_dim, 
+        output_dim, 
+        inputs,
+        biases=True,
+        initialization=None,
+        weightnorm=None,
+        gain=1.
+        ):
+    """
+    initialization: None, `lecun`, 'glorot', `he`, 'glorot_he', `orthogonal`, `("uniform", range)`
+    """
+    with tf.name_scope(name) as scope:
+
+        def uniform(stdev, size):
+            if _weights_stdev is not None:
+                stdev = _weights_stdev
+            return np.random.uniform(
+                low=-stdev * np.sqrt(3),
+                high=stdev * np.sqrt(3),
+                size=size
+            ).astype('float32')
+
+        if initialization == 'lecun':# and input_dim != output_dim):
+            # disabling orth. init for now because it's too slow
+            weight_values = uniform(
+                np.sqrt(1./input_dim),
+                (input_dim, output_dim)
+            )
+
+        elif initialization == 'glorot' or (initialization == None):
+
+            weight_values = uniform(
+                np.sqrt(2./(input_dim+output_dim)),
+                (input_dim, output_dim)
+            )
+
+        elif initialization == 'he':
+
+            weight_values = uniform(
+                np.sqrt(2./input_dim),
+                (input_dim, output_dim)
+            )
+
+        elif initialization == 'glorot_he':
+
+            weight_values = uniform(
+                np.sqrt(4./(input_dim+output_dim)),
+                (input_dim, output_dim)
+            )
+
+        elif initialization == 'orthogonal' or \
+            (initialization == None and input_dim == output_dim):
+            
+            # From lasagne
+            def sample(shape):
+                if len(shape) < 2:
+                    raise RuntimeError("Only shapes of length 2 or more are "
+                                       "supported.")
+                flat_shape = (shape[0], np.prod(shape[1:]))
+                 # TODO: why normal and not uniform?
+                a = np.random.normal(0.0, 1.0, flat_shape)
+                u, _, v = np.linalg.svd(a, full_matrices=False)
+                # pick the one with the correct shape
+                q = u if u.shape == flat_shape else v
+                q = q.reshape(shape)
+                return q.astype('float32')
+            weight_values = sample((input_dim, output_dim))
+        
+        elif initialization[0] == 'uniform':
+        
+            weight_values = np.random.uniform(
+                low=-initialization[1],
+                high=initialization[1],
+                size=(input_dim, output_dim)
+            ).astype('float32')
+
+        else:
+
+            raise Exception('Invalid initialization!')
+
+        weight_values *= gain
+
+        weight = lib.param(
+            name + '.W',
+            weight_values
+        )
+
+        if weightnorm==None:
+            weightnorm = _default_weightnorm
+        if weightnorm:
+            norm_values = np.sqrt(np.sum(np.square(weight_values), axis=0))
+            # norm_values = np.linalg.norm(weight_values, axis=0)
+
+            target_norms = lib.param(
+                name + '.g',
+                norm_values
+            )
+
+            with tf.name_scope('weightnorm') as scope:
+                norms = tf.sqrt(tf.reduce_sum(tf.square(weight), reduction_indices=[0]))
+                weight = weight * (target_norms / norms)
+
+        # if 'Discriminator' in name:
+        #     print "WARNING weight constraint on {}".format(name)
+        #     weight = tf.nn.softsign(10.*weight)*.1
+
+        if inputs.get_shape().ndims == 2:
+            result = tf.matmul(inputs, weight)
+        else:
+            reshaped_inputs = tf.reshape(inputs, [-1, input_dim])
+            result = tf.matmul(reshaped_inputs, weight)
+            result = tf.reshape(result, tf.pack(tf.unpack(tf.shape(inputs))[:-1] + [output_dim]))
+
+        if biases:
+            result = tf.nn.bias_add(
+                result,
+                lib.param(
+                    name + '.b',
+                    np.zeros((output_dim,), dtype='float32')
+                )
+            )
+
+        return result


### PR DESCRIPTION
This PR adds:
- A GAN example for the 2-D Ising model.  Dataset is generated by `spin.Model()` class.  Includes [DCGAN](https://arxiv.org/abs/1511.06434), [WGAN](https://arxiv.org/abs/1701.07875), and [WGAN-GP](https://arxiv.org/abs/1704.00028) models.  Adapted from [original code](https://github.com/igul222/improved_wgan_training).

For now, system size is fixed to 16x16.  Future PRs will address generalization to system sizes of arbitrary powers of 2, make the discriminator fully convolutional, and the evaluation of ensemble averages/fluctuations for fake data (once the functionality in `spin` is added).